### PR TITLE
expose websocket electrs API using `websocat`

### DIFF
--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
@@ -1,10 +1,10 @@
 # Electrs build stage
-FROM rust:latest AS electrs-builder
+FROM rust:latest AS builder
 
 ARG COMMIT=253040e346664976c12e6c214ee2858a4dad2e06
 
 RUN apt-get update
-RUN apt-get install -y clang cmake
+RUN apt-get install -y clang cmake 
 
 RUN git clone https://github.com/blockstream/electrs && cd electrs && git checkout ${COMMIT}
 
@@ -12,28 +12,19 @@ WORKDIR /electrs
 
 RUN cargo build --release --bin electrs
 
-# websocat build stage
-FROM rust:1.60-alpine3.15 as cargo-build
+FROM debian:stable-slim AS websocat-installer
 
-RUN apk add --no-cache musl-dev pkgconfig openssl-dev git
+RUN apt-get update
+RUN apt-get install -y wget
 
-RUN git clone https://github.com/vi/websocat.git && cd websocat && git checkout v1.11.0
-
-WORKDIR /websocat
-
-ARG CARGO_OPTS="--features=workaround1,seqpacket,prometheus_peer,prometheus/process,crypto_peer"
-
-RUN cargo build --release --target=x86_64-unknown-linux-musl $CARGO_OPTS && \
-    rm -f target/x86_64-unknown-linux-musl/release/deps/websocat*
-
-RUN cargo build --release --target=x86_64-unknown-linux-musl $CARGO_OPTS && \
-    strip target/x86_64-unknown-linux-musl/release/websocat
+COPY install-websocat.sh /install-websocat.sh
+RUN chmod +x /install-websocat.sh && /install-websocat.sh
 
 # Final stage
 FROM debian:stable-slim
 
-COPY --from=electrs-builder /electrs/target/release/electrs /usr/local/bin
-COPY --from=cargo-build /websocat/target/x86_64-unknown-linux-musl/release/websocat /usr/local/bin
+COPY --from=builder /electrs/target/release/electrs /usr/local/bin
+COPY --from=websocat-installer /usr/local/bin/websocat /usr/local/bin
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
@@ -1,4 +1,5 @@
-FROM rust:latest AS builder
+# Electrs build stage
+FROM rust:latest AS electrs-builder
 
 ARG COMMIT=253040e346664976c12e6c214ee2858a4dad2e06
 
@@ -11,12 +12,31 @@ WORKDIR /electrs
 
 RUN cargo build --release --bin electrs
 
+# websocat build stage
+FROM rust:1.60-alpine3.15 as cargo-build
+
+RUN apk add --no-cache musl-dev pkgconfig openssl-dev git
+
+RUN git clone https://github.com/vi/websocat.git && cd websocat && git checkout v1.11.0
+
+WORKDIR /websocat
+
+ARG CARGO_OPTS="--features=workaround1,seqpacket,prometheus_peer,prometheus/process,crypto_peer"
+
+RUN cargo build --release --target=x86_64-unknown-linux-musl $CARGO_OPTS && \
+    rm -f target/x86_64-unknown-linux-musl/release/deps/websocat*
+
+RUN cargo build --release --target=x86_64-unknown-linux-musl $CARGO_OPTS && \
+    strip target/x86_64-unknown-linux-musl/release/websocat
+
+# Final stage
 FROM debian:stable-slim
 
-WORKDIR /build
+COPY --from=electrs-builder /electrs/target/release/electrs /usr/local/bin
+COPY --from=cargo-build /websocat/target/x86_64-unknown-linux-musl/release/websocat /usr/local/bin
 
-COPY --from=builder /electrs/target/release/electrs /build
+COPY entrypoint.sh /entrypoint.sh
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/build/electrs"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
@@ -4,6 +4,7 @@ FROM rust:latest AS builder
 ARG COMMIT=253040e346664976c12e6c214ee2858a4dad2e06
 
 ENV WS_PORT=1234
+ENV ELECTRUM_PORT=50001
 
 RUN apt-get update
 RUN apt-get install -y clang cmake 
@@ -34,4 +35,4 @@ RUN chmod +x /entrypoint.sh
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT /entrypoint.sh ${WS_PORT}
+ENTRYPOINT /entrypoint.sh ${WS_PORT} ${ELECTRUM_PORT}

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
@@ -3,6 +3,8 @@ FROM rust:latest AS builder
 
 ARG COMMIT=253040e346664976c12e6c214ee2858a4dad2e06
 
+ENV WS_PORT=1234
+
 RUN apt-get update
 RUN apt-get install -y clang cmake 
 
@@ -28,7 +30,8 @@ COPY --from=builder /electrs/target/release/electrs /usr/local/bin
 COPY --from=websocat-installer /usr/local/bin/websocat /usr/local/bin
 
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["bash", "/entrypoint.sh"]
+ENTRYPOINT /entrypoint.sh ${WS_PORT}

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
@@ -39,4 +39,4 @@ COPY entrypoint.sh /entrypoint.sh
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/entrypoint.sh"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile
@@ -17,8 +17,9 @@ FROM debian:stable-slim AS websocat-installer
 RUN apt-get update
 RUN apt-get install -y wget
 
-COPY install-websocat.sh /install-websocat.sh
-RUN chmod +x /install-websocat.sh && /install-websocat.sh
+RUN wget https://github.com/vi/websocat/releases/download/v1.11.0/websocat.x86_64-unknown-linux-musl \
+    && chmod +x websocat.x86_64-unknown-linux-musl \
+    && mv websocat.x86_64-unknown-linux-musl /usr/local/bin/websocat
 
 # Final stage
 FROM debian:stable-slim

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
@@ -16,8 +16,9 @@ FROM debian:stable-slim AS websocat-installer
 RUN apt-get update
 RUN apt-get install -y wget
 
-COPY install-websocat.sh /install-websocat.sh
-RUN chmod +x /install-websocat.sh && /install-websocat.sh
+RUN wget https://github.com/vi/websocat/releases/download/v1.11.0/websocat.x86_64-unknown-linux-musl \
+    && chmod +x websocat.x86_64-unknown-linux-musl \
+    && mv websocat.x86_64-unknown-linux-musl /usr/local/bin/websocat
 
 FROM debian:stable-slim
 

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
@@ -11,12 +11,21 @@ WORKDIR /electrs
 
 RUN cargo build --features liquid --release --bin electrs
 
+FROM debian:stable-slim AS websocat-installer
+
+RUN apt-get update
+RUN apt-get install -y wget
+
+COPY install-websocat.sh /install-websocat.sh
+RUN chmod +x /install-websocat.sh && /install-websocat.sh
+
 FROM debian:stable-slim
 
 WORKDIR /build
 
-COPY --from=builder /electrs/target/release/electrs /build
+COPY --from=builder /electrs/target/release/electrs /usr/local/bin
+COPY --from=websocat-installer /usr/local/bin/websocat /usr/local/bin
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["/build/electrs"]
+ENTRYPOINT ["bash", "/entrypoint.sh"]

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
@@ -3,6 +3,7 @@ FROM rust:latest AS builder
 ARG COMMIT=a808b51d0d9301fa82390b985c57551966001f9b
 
 ENV WS_PORT=1234
+ENV ELECTRUM_PORT=50001
 
 RUN apt-get update
 RUN apt-get install -y clang cmake
@@ -34,4 +35,4 @@ RUN chmod +x /entrypoint.sh
 
 STOPSIGNAL SIGINT
 
-ENTRYPOINT /entrypoint.sh ${WS_PORT}
+ENTRYPOINT /entrypoint.sh ${WS_PORT} ${ELECTRUM_PORT}

--- a/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
+++ b/a808b51d0d9301fa82390b985c57551966001f9b/Dockerfile.liquid
@@ -2,6 +2,8 @@ FROM rust:latest AS builder
 
 ARG COMMIT=a808b51d0d9301fa82390b985c57551966001f9b
 
+ENV WS_PORT=1234
+
 RUN apt-get update
 RUN apt-get install -y clang cmake
 
@@ -27,6 +29,9 @@ WORKDIR /build
 COPY --from=builder /electrs/target/release/electrs /usr/local/bin
 COPY --from=websocat-installer /usr/local/bin/websocat /usr/local/bin
 
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
 STOPSIGNAL SIGINT
 
-ENTRYPOINT ["bash", "/entrypoint.sh"]
+ENTRYPOINT /entrypoint.sh ${WS_PORT}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#/!bin/bash
+#!/bin/bash
 set -m
 electrs&
 websocat -b ws-l:127.0.0.1:1234 tcp:127.0.0.1:50001&

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,5 @@
 #/!bin/bash
 set -m
-electrs &
-websocat --oneshot -b ws-l:127.0.0.1:1234 tcp:127.0.0.1:50001&
+electrs&
+websocat -b ws-l:127.0.0.1:1234 tcp:127.0.0.1:50001&
 fg %1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 
 PORT=$1
+ELECTRUM_RPC_PORT=$2
 
-if [ -z "$PORT" ]; then
-    echo "Usage: $0 <WS_PORT>"
+if [ -z "$PORT" ] || [ -z "$ELECTRUM_RPC_PORT" ]; then
+    echo "Usage: $0 <WS_PORT> <ELECTRUM_RPC_PORT>"
     exit 1
 fi
 
@@ -11,5 +12,5 @@ echo "Starting websocket server on port $PORT"
 
 set -m
 electrs&
-websocat -b ws-l:127.0.0.1:$PORT tcp:127.0.0.1:50001&
+websocat -b ws-l:127.0.0.1:$PORT tcp:127.0.0.1:$ELECTRUM_RPC_PORT&
 fg %1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
+
+PORT=$1
+
+if [ -z "$PORT" ]; then
+    echo "Usage: $0 <WS_PORT>"
+    exit 1
+fi
+
+echo "Starting websocket server on port $PORT"
+
 set -m
 electrs&
-websocat -b ws-l:127.0.0.1:1234 tcp:127.0.0.1:50001&
+websocat -b ws-l:127.0.0.1:$PORT tcp:127.0.0.1:50001&
 fg %1

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,5 @@
+#/!bin/bash
+set -m
+electrs &
+websocat --oneshot -b ws-l:127.0.0.1:1234 tcp:127.0.0.1:50001&
+fg %1

--- a/install-websocat.sh
+++ b/install-websocat.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+wget https://github.com/vi/websocat/releases/download/v1.11.0/websocat.x86_64-unknown-linux-musl
+chmod +x websocat.x86_64-unknown-linux-musl
+mv websocat.x86_64-unknown-linux-musl /usr/local/bin/websocat

--- a/install-websocat.sh
+++ b/install-websocat.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-wget https://github.com/vi/websocat/releases/download/v1.11.0/websocat.x86_64-unknown-linux-musl
-chmod +x websocat.x86_64-unknown-linux-musl
-mv websocat.x86_64-unknown-linux-musl /usr/local/bin/websocat


### PR DESCRIPTION
* `entrypoint.sh` is running `electrs` & `websocat` in background.
* @tiero should we fetch the websocat binary instead of building it?

